### PR TITLE
Feature undesired tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Command line parameters can be used to customize the results. The usage is:
 | `--filterFile <file>` | `-ff`  | Custom filter file that is used to define POI categories | [filters.txt](https://github.com/MorbZ/OsmPoisPbf/blob/master/res/filters.txt) |
 | `--outputFile <file>` | `-of` | The name of the resulting CSV file | Name of input file with .csv extension |
 | `--requiredTags <list>` | `-rt` | Comma separated list of tags (keys) that an element must have in order to be considered for export. Use `,` as argument to make it empty. | `name` |
+| `--undesiredTags <list>` | `-rt` | Comma separated list of tags=value combinations that should be filtered [key=value]. | |
 | `--outputTags <list>` | `-ot` | Comma separated list of tags that are exported. Use `,` as argument to make it empty. | `name` |
 | `--relations` | `-r` | Also parse relations. By default only ways and nodes are parsed. Requires more RAM and more time. | |
 | `--noWays` | `-nw` | Don't parse ways/areas | |

--- a/src/de/morbz/osmpoispbf/Scanner.java
+++ b/src/de/morbz/osmpoispbf/Scanner.java
@@ -260,7 +260,7 @@ public class Scanner {
 		    	
 				entityNeeded = getCategory(tags, filters) != null;
 
-				if(undesiredTags != null){
+				if(undesiredTags != null && entityNeeded){
 					for (String key: undesiredTags.keySet()) {
 						if(tags.hasKey(key)){
 							for (String val: undesiredTags.get(key)) {

--- a/src/de/morbz/osmpoispbf/Scanner.java
+++ b/src/de/morbz/osmpoispbf/Scanner.java
@@ -258,7 +258,6 @@ public class Scanner {
 		    		}
 		    	}
 		    	
-		    	// Check category
 				entityNeeded = getCategory(tags, filters) != null;
 
 				if(undesiredTags != null){


### PR DESCRIPTION
This PR intents to fix #8. It provides the ability to add a command line argument,  that filters certain tag=value combinations.

For example when using the latest monaco.osm.pbf extract from GeoFabrik and using the following undesired tags filter: `-undesiredTags name=Monte-Carlo,name=Castelleretto` the POI file gets reduced by 5 POIs that have one of the given names.

The implementation might not be highly efficient, but this should only matter for anyone that wants to use this feature, still it should not be too bad. I tried to keep the impact for users that don't need the feature minimal.

Let me know what you think, and if I should improve anything?
